### PR TITLE
Fix docker examples in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,10 +64,10 @@ services:
     restart: unless-stopped
     environment:
       - TZ=Europe/Paris
-      - USER="username"
-      - PASSWORD="password"
+      - USER=username
+      - PASSWORD=password
       - SERVICE=freedns
-      - HOSTNAME="sub.example.com"
+      - HOSTNAME=sub.example.com
       - DETECTIP=1
       - INTERVAL=10
     healthcheck:

--- a/README.md
+++ b/README.md
@@ -50,7 +50,7 @@ $ docker pull joweisberg/dynamic-dns:latest
 ### Run the container in *console mode* (notice the environment variable setting parameters for the startup command)
 
 ```bash
-$ docker run -d --restart="unless-stopped" -e TZ="Europe/Paris" -e USER="username" -e PASSWORD="password" -e SERVICE="freedns" -e HOSTNAME="sub.example.com" -e DETECTIP=1 -e INTERVAL=10 joweisberg/dynamic-dns:latest
+$ docker run -d --restart=unless-stopped -e TZ=Europe/Paris -e USER=username -e PASSWORD=password -e SERVICE=freedns -e HOSTNAME=sub.example.com -e DETECTIP=1 -e INTERVAL=10 joweisberg/dynamic-dns:latest
 ```
 
 ### Run the container via docker-compose
@@ -64,10 +64,10 @@ services:
     restart: unless-stopped
     environment:
       - TZ=Europe/Paris
-      - USER="username"
-      - PASSWORD="password"
+      - USER=username
+      - PASSWORD=password
       - SERVICE=freedns
-      - HOSTNAME="sub.example.com"
+      - HOSTNAME=sub.example.com
       - DETECTIP=1
       - INTERVAL=10
     healthcheck:


### PR DESCRIPTION
Fixed the example `docker-compose.yml` cofiguration to remove confusion as noted in [Issue 1](https://github.com/joweisberg/docker-dynamic-dns/issues/1) and [Issue 2](https://github.com/joweisberg/docker-dynamic-dns/issues/2).